### PR TITLE
Update command to also install Input component when setting up Form component

### DIFF
--- a/apps/www/content/docs/components/form.mdx
+++ b/apps/www/content/docs/components/form.mdx
@@ -88,7 +88,7 @@ const form = useForm()
 ### Command
 
 ```bash
-npx shadcn@latest add form
+npx shadcn@latest add form input
 ```
 
 </Steps>


### PR DESCRIPTION
The [Form](https://ui.shadcn.com/docs/components/form) component requires the [Input](https://ui.shadcn.com/docs/components/input) component to be installed.

This PR proposes to add the `Input` argument to the `npx` command used to install Form, so that it works out of the box.

Ideally, the background process (behind `npx add ...`) could also be updated to cater for this missing dependency.